### PR TITLE
Fix broken URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ![Download count all time](https://img.shields.io/npm/dt/ember-math-helpers.svg)
 [![npm](https://img.shields.io/npm/dm/ember-math-helpers.svg)]()
 [![Ember Observer Score](http://emberobserver.com/badges/ember-math-helpers.svg)](http://emberobserver.com/addons/ember-math-helpers)
-![CI Build](https://github.com/rwwagner90/ember-math-helpers/workflows/CI%20Build/badge.svg)
+![CI Build](https://github.com/RobbieTheWagner/ember-math-helpers/workflows/CI%20Build/badge.svg)
 [![Code Climate](https://codeclimate.com/github/rwwagner90/ember-math-helpers/badges/gpa.svg)](https://codeclimate.com/github/rwwagner90/ember-math-helpers)
 [![Test Coverage](https://codeclimate.com/github/rwwagner90/ember-math-helpers/badges/coverage.svg)](https://codeclimate.com/github/rwwagner90/ember-math-helpers/coverage)
 
@@ -26,7 +26,7 @@ HTMLBars template helpers for doing basic arithmetic operations
 
 ## Documentation
 
-[View Docs](https://rwwagner90.github.io/ember-math-helpers/)
+[View Docs](https://robbiethewagner.github.io/ember-math-helpers/)
 
 ## Contributing
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -8,7 +8,7 @@
 ![Download count all time](https://img.shields.io/npm/dt/ember-math-helpers.svg)
 [![npm](https://img.shields.io/npm/dm/ember-math-helpers.svg)]()
 [![Ember Observer Score](http://emberobserver.com/badges/ember-math-helpers.svg)](http://emberobserver.com/addons/ember-math-helpers)
-![CI Build](https://github.com/rwwagner90/ember-math-helpers/workflows/CI%20Build/badge.svg)
+![CI Build](https://github.com/RobbieTheWagner/ember-math-helpers/workflows/CI%20Build/badge.svg)
 [![Code Climate](https://codeclimate.com/github/rwwagner90/ember-math-helpers/badges/gpa.svg)](https://codeclimate.com/github/rwwagner90/ember-math-helpers)
 [![Test Coverage](https://codeclimate.com/github/rwwagner90/ember-math-helpers/badges/coverage.svg)](https://codeclimate.com/github/rwwagner90/ember-math-helpers/coverage)
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "private": true,
   "description": "The documentation site for ember-math-helpers",
-  "homepage": "https://rwwagner90.github.io/ember-math-helpers",
-  "repository": "https://github.com/rwwagner90/ember-math-helpers",
+  "homepage": "https://robbiethewagner.github.io/ember-math-helpers",
+  "repository": "https://github.com/RobbieTheWagner/ember-math-helpers",
   "license": "MIT",
   "author": "",
   "directories": {

--- a/ember-math-helpers/README.md
+++ b/ember-math-helpers/README.md
@@ -8,7 +8,7 @@
 ![Download count all time](https://img.shields.io/npm/dt/ember-math-helpers.svg)
 [![npm](https://img.shields.io/npm/dm/ember-math-helpers.svg)]()
 [![Ember Observer Score](http://emberobserver.com/badges/ember-math-helpers.svg)](http://emberobserver.com/addons/ember-math-helpers)
-![CI Build](https://github.com/rwwagner90/ember-math-helpers/workflows/CI%20Build/badge.svg)
+![CI Build](https://github.com/RobbieTheWagner/ember-math-helpers/workflows/CI%20Build/badge.svg)
 [![Code Climate](https://codeclimate.com/github/rwwagner90/ember-math-helpers/badges/gpa.svg)](https://codeclimate.com/github/rwwagner90/ember-math-helpers)
 [![Test Coverage](https://codeclimate.com/github/rwwagner90/ember-math-helpers/badges/coverage.svg)](https://codeclimate.com/github/rwwagner90/ember-math-helpers/coverage)
 
@@ -26,7 +26,7 @@ HTMLBars template helpers for doing basic arithmetic operations
 
 ## Documentation
 
-[View Docs](https://rwwagner90.github.io/ember-math-helpers/)
+[View Docs](https://robbiethewagner.github.io/ember-math-helpers/)
 
 ## Contributing
 

--- a/ember-math-helpers/package.json
+++ b/ember-math-helpers/package.json
@@ -5,12 +5,12 @@
   "keywords": [
     "ember-addon"
   ],
-  "repository": "https://github.com/rwwagner90/ember-math-helpers",
+  "repository": "https://github.com/RobbieTheWagner/ember-math-helpers",
   "license": "MIT",
   "author": {
     "name": "Robert Wagner",
     "email": "rwwagner90@gmail.com",
-    "url": "https://github.com/rwwagner90"
+    "url": "https://github.com/RobbieTheWagner"
   },
   "exports": {
     "./*": "./dist/*"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "private": true,
-  "repository": "https://github.com/rwwagner90/ember-math-helpers",
+  "repository": "https://github.com/RobbieTheWagner/ember-math-helpers",
   "license": "MIT",
   "author": {
     "name": "Robert Wagner",
     "email": "rwwagner90@gmail.com",
-    "url": "https://github.com/rwwagner90"
+    "url": "https://github.com/RobbieTheWagner"
   },
   "scripts": {
     "ember-try-one": "pnpm -F test-app ember-try-one",


### PR DESCRIPTION
The URL for Code Climate does not appear to have changed at this time; you may need to resync your GitHub account.
Also, the URL to the documentation site in the repository description will need to be changed as well.
