### PR TITLE
fix: Make sure that global imports/exports do work

### DIFF
--- a/ember-math-helpers/rollup.config.mjs
+++ b/ember-math-helpers/rollup.config.mjs
@@ -14,7 +14,7 @@ export default {
   plugins: [
     // These are the modules that users should be able to import from your
     // addon. Anything not listed here may get optimized away.
-    addon.publicEntrypoints(['helpers/**/*.js', 'template-registry.js']),
+    addon.publicEntrypoints(['helpers/**/*.js', 'template-registry.js', 'index.js']),
 
     // These are the modules that should get reexported into the traditional
     // "app" tree. Things in here should also be in publicEntrypoints above, but


### PR DESCRIPTION
With this change following import should work:

```
import { sum } from "ember-math-helpers";
```

Fixes: #1673