### PR TITLE
Add Ember v6 Peer Support

### DIFF
--- a/ember-math-helpers/package.json
+++ b/ember-math-helpers/package.json
@@ -64,7 +64,7 @@
     "rollup": "^4.24.0"
   },
   "peerDependencies": {
-    "ember-source": "^4.0.0 || ^5.0.0"
+    "ember-source": ">= 4.0.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Changing this to the format in the current ember-cli blueprint to support the brand new ember [6.0.0 release](https://github.com/emberjs/ember.js/releases/tag/v6.0.0-ember-source).